### PR TITLE
chore: rename ergo.go to port.go

### DIFF
--- a/port.go
+++ b/port.go
@@ -1,4 +1,4 @@
-package erlgo
+package port
 
 import (
 	"bufio"


### PR DESCRIPTION
This pull request renames `ergo.go` to `port.go`