### PR TITLE
chore: add go work setup to examples README

### DIFF
--- a/examples/erlang_go/README.md
+++ b/examples/erlang_go/README.md
@@ -13,6 +13,10 @@ An OTP library that communicates to go via ports.
 ### Build Go
 
 ```bash
+go work init
+
+go work use go_src/hello_world
+
 make build
 ```
 


### PR DESCRIPTION
This pull request adds `go work` setup to examples README